### PR TITLE
fix(markdown): harden rendering while preserving inline links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 				"bits-ui": "^2.16.3",
 				"class-variance-authority": "^0.7.0",
 				"clsx": "^2.1.1",
-				"dompurify": "^3.3.1",
 				"lucide-svelte": "^0.414.0",
 				"marked": "^13.0.3",
 				"mode-watcher": "^0.4.0",
@@ -3353,15 +3352,6 @@
 			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
 			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
 			"license": "MIT"
-		},
-		"node_modules/dompurify": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-			"integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"optionalDependencies": {
-				"@types/trusted-types": "^2.0.7"
-			}
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.286",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"bits-ui": "^2.16.3",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
-		"dompurify": "^3.3.1",
 		"lucide-svelte": "^0.414.0",
 		"marked": "^13.0.3",
 		"mode-watcher": "^0.4.0",

--- a/src/lib/components/portfolio/HackathonCard.svelte
+++ b/src/lib/components/portfolio/HackathonCard.svelte
@@ -34,7 +34,7 @@
 		{/if}
 		{#if description}
 			<span class="prose text-sm text-muted-foreground dark:prose-invert">
-				<!-- HTML comes from marked() and is sanitized with DOMPurify -->
+				<!-- HTML comes from the hardened markdown renderer -->
 				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 				{@html htmlDescription}
 			</span>

--- a/src/lib/components/portfolio/ProjectCard.svelte
+++ b/src/lib/components/portfolio/ProjectCard.svelte
@@ -50,7 +50,7 @@
 				class="prose max-w-full text-pretty font-sans text-xs text-muted-foreground dark:prose-invert"
 			>
 				{#if description}
-					<!-- HTML comes from marked() and is sanitized with DOMPurify -->
+					<!-- HTML comes from the hardened markdown renderer -->
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					{@html htmlDescription}
 				{/if}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,19 +1,39 @@
-import { marked } from 'marked';
-import { browser } from '$app/environment';
-import type { default as DOMPurifyType } from 'dompurify';
+import { Marked } from 'marked';
 
-let DOMPurify: typeof DOMPurifyType | null = null;
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
 
-if (browser) {
-	import('dompurify').then((mod) => {
-		DOMPurify = (mod.default ?? mod) as typeof DOMPurifyType;
-	});
+function isSafeHref(href: string): boolean {
+	const value = href.trim();
+	if (!value) return false;
+	if (value.startsWith('#')) return true;
+	if (value.startsWith('/')) return true;
+	if (value.startsWith('./') || value.startsWith('../')) return true;
+	if (value.startsWith('//')) return true;
+
+	try {
+		const url = new URL(value);
+		return SAFE_PROTOCOLS.has(url.protocol);
+	} catch {
+		return false;
+	}
 }
 
+const markdown = new Marked({ gfm: true, breaks: false });
+
+markdown.use({
+	walkTokens(token) {
+		if (token.type === 'link' && !isSafeHref(token.href ?? '')) {
+			token.href = '#';
+		}
+
+		if (token.type === 'image' && !isSafeHref(token.href ?? '')) {
+			token.href = '';
+		}
+	}
+});
+
 export function renderMarkdownSafe(md: string): string {
-	const html = marked.parse(md ?? '') as string;
-
-	if (!browser) return html;
-
-	return DOMPurify ? DOMPurify.sanitize(html) : html;
+	// Escape raw HTML so markdown content cannot inject arbitrary tags/scripts.
+	const escaped = (md ?? '').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+	return markdown.parse(escaped) as string;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -65,7 +65,7 @@
 			<div
 				class="prose max-w-full text-pretty font-sans text-sm text-muted-foreground dark:prose-invert"
 			>
-				<!-- HTML comes from marked() and is sanitized with DOMPurify -->
+				<!-- HTML comes from the hardened markdown renderer -->
 				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 				{@html renderMarkdownSafe($DATA.summary)}
 			</div>


### PR DESCRIPTION
Closes #7

## Summary
This PR hardens markdown rendering used across the portfolio while preserving valid inline links in content (e.g., About section).

## Changes
- remove runtime dependence on DOMPurify in markdown helper
- neutralize unsafe URL protocols in markdown links/images
- escape raw HTML in markdown input
- keep markdown links rendering correctly
- update related inline comments in components

## Validation
- npm run check
- npm run lint
- npm run build

All commands pass locally.